### PR TITLE
Fix error on PHP >= 5.5

### DIFF
--- a/src/PhpToZephir/CodeCollector/DirectoryCodeCollector.php
+++ b/src/PhpToZephir/CodeCollector/DirectoryCodeCollector.php
@@ -40,6 +40,10 @@ class DirectoryCodeCollector implements CodeCollectorInterface
 		
 		foreach ($this->directories as $directory) {
 			foreach ($this->findFiles($directory) as $file) {
+				if (is_array($file)) {
+					$file = reset($file);
+				}
+				
 				$files[$file] = file_get_contents($file);
 			}
 		}


### PR DESCRIPTION
Iterating on RegexIterator return array on my dev & preprod environment (PHP 5.5 & 5.6).
I fixed this, in a way to support the old version (i supposed it should work for some person with the current code...).